### PR TITLE
Change `hyperterm` to `hyper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # hyperfull
 [![Dependency Status](https://david-dm.org/simonmeusel/hyperfull.svg)](https://david-dm.org/simonmeusel/hyperfull)
 
-Allows you to open hyperterm in fullscreen.
+Allows you to open Hyper in fullscreen.
 
 ## Installation
-Add `hyperfull` to your HyperTerm plugins.
+Add `hyperfull` to your Hyper plugins.
 
 ## Usage
 After installing, your terminal will open in full screen mode.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperfull",
   "version": "1.0.1",
-  "description": "Allows you to open hyperterm in fullscreen",
+  "description": "Allows you to open Hyper in fullscreen",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -12,7 +12,7 @@
   },
   "keywords": [
     "Fullscreen",
-    "Hyperterm",
+    "hyper",
     "Terminal",
     "Plugin"
   ],


### PR DESCRIPTION
Because: https://zeit.co/blog/the-hyper-plan
